### PR TITLE
Add support for delta-time playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Manually set the frame to display.
 ## `AnimatedImage:getFrame()`
 Get the currently displayed frame.
 
+## `AnimatedImage:setTime(milliseconds)`
+Manually set the current time when using delta-time playback (see `update`).
+
+`milliseconds` is the total elapsed time.
+
+## `AnimatedImage:getTime()`
+Get the current elapsed time when using delta-time playback (see `update`).
+
 ## `AnimatedImage:setFirstFrame(frame)`
 Set the frame the animation starts and loops from.
 
@@ -85,3 +93,8 @@ Determine if an animated image has finished animating. However, this will always
 
 ## `AnimatedImage:getImage()`
 Returns the image for the current frame.
+
+## `AnimatedImage:update(dt)`
+Call this each frame to update the elapsed time for delta-time playback. Calling `update` is strictly _optional_, and only necessary when you wish to perform time-based synchronization or achieve time dilation effects.
+
+`dt` is the elapsed time since the last call to `update`, in milliseconds.

--- a/animatedimage.lua
+++ b/animatedimage.lua
@@ -45,12 +45,14 @@ function AnimatedImage.new(image_table_path, options)
 	setmetatable(animated_image, AnimatedImage)
 	animated_image.image_table = image_table
 	animated_image.loop = animation_loop
+	animated_image.elapsedTime = 0
 	
 	return animated_image
 end
 
 function AnimatedImage:reset()
 	self.loop.frame = self.loop.startFrame
+	self.elapsedTime = 0
 end
 
 function AnimatedImage:setDelay(delay)
@@ -93,6 +95,14 @@ function AnimatedImage:getFrame()
 	return self.loop.frame
 end
 
+function AnimatedImage:setTime(milliseconds)
+	self.elapsedTime = milliseconds
+end
+
+function AnimatedImage:getTime()
+	return self.elapsedTime
+end
+
 function AnimatedImage:setFirstFrame(frame)
 	self.loop.startFrame = frame
 end
@@ -107,6 +117,19 @@ end
 
 function AnimatedImage:getImage()
 	return self.image_table:getImage(self.loop.frame)
+end
+
+-- calling update is OPTIONAL, and only necessary when you wish to use time-based synchronization for the animation
+-- dt: the elapsed time since the last call to update, in milliseconds
+function AnimatedImage:update(dt)
+	if self.loop.paused then return end
+	self.elapsedTime += dt
+	local frameDelta = self.elapsedTime / self.loop.delay * self.loop.step * 1000
+	local maxFrameDelta = self.loop.endFrame - self.loop.startFrame
+	if frameDelta > maxFrameDelta then
+		frameDelta = self.loop.shouldLoop and frameDelta % maxFrameDelta or maxFrameDelta
+	end
+	self.loop.frame = self.loop.startFrame + frameDelta
 end
 
 AnimatedImage.__index = function(animated_image, key)


### PR DESCRIPTION
This adds the option to use delta-time playback as needed to perform time-based synchronization or achieve time dilation effects. Calling `update(dt)` each frame will override the underlying animation loop timing and set the appropriate frame according to the elapsed time, while respecting all available options (`delay`, `loop`, `step`, `startFrame`, `endFrame`, `paused`, etc.). If `update` is not called, the behavior remains unchanged.